### PR TITLE
Add joke controller 

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeController.java
@@ -2,7 +2,46 @@ package edu.ucsb.cs156.spring.backenddemo.controllers;
 
 import org.springframework.web.bind.annotation.RestController;
 
+import edu.ucsb.cs156.spring.backenddemo.services.JokeQueryService;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Random Jokes from a Joke API")
+@Slf4j
 @RestController
+@RequestMapping("/api/jokes")
 public class JokeController {
-    
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    JokeQueryService jokeQueryService;
+
+    @Operation(summary = "Get random jokes", description = "Fetches a specified number of random jokes from an external joke API. Categories can include 'knock-knock', 'dad', 'general', etc.")
+    @GetMapping("/get")
+    public ResponseEntity<String> getRandomJokes(
+        @Parameter(name = "category", description = "Category of the joke", example = "dad")
+        @RequestParam(required = false) String category,
+        @Parameter(name = "numJokes", description = "Number of jokes to fetch", example = "3")
+        @RequestParam(required = false, defaultValue = "1") int numJokes
+    ) throws JsonProcessingException {
+        log.info("getRandomJokes: category={}, numJokes={}", category, numJokes);
+        String result = jokeQueryService.getJSON(category, numJokes);
+        return ResponseEntity.ok().body(result);
+    }
 }
+
+
+

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryService.java
@@ -1,11 +1,26 @@
+
+
 package edu.ucsb.cs156.spring.backenddemo.services;
 
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.springframework.web.client.RestTemplate;
 
+import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+
+@Slf4j
 @Service
 public class JokeQueryService {
 
@@ -15,9 +30,20 @@ public class JokeQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "https://v2.jokeapi.dev/joke/{category}?amount={numJokes}";
 
     public String getJSON(String category, int numJokes) throws HttpClientErrorException {
-        return "";
+        log.info("category={}, numJokes={}", category, numJokes);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        Map<String, String> uriVariables = Map.of("category", category, "numJokes", Integer.toString(numJokes));
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class, uriVariables);
+        return re.getBody();
     }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
@@ -1,0 +1,69 @@
+
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.JokeQueryService;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(value = JokeController.class)
+public class JokeControllerTests {
+  
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    JokeQueryService mockJokeQueryService;
+
+    @Test
+    public void test_getRandomJoke() throws Exception {
+    
+        String fakeJsonResult = "{ \"joke\" : \"Why don't scientists trust atoms? Because they make up everything!\" }";
+        String category = "dad";
+        int numJokes = 1; // Assuming you want 1 joke
+        when(mockJokeQueryService.getJSON(eq(category), eq(numJokes))).thenReturn(fakeJsonResult);
+
+        String url = String.format("/api/jokes/get?category=%s&numJokes=%d", category, numJokes);
+
+        MvcResult response = mockMvc
+            .perform(get(url).contentType("application/json"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(fakeJsonResult, responseString);
+    }
+
+    @Test
+    public void test_getRandomJoke_noCategory() throws Exception {
+    
+        String fakeJsonResult = "{ \"joke\" : \"Parallel lines have so much in common. It’s a shame they’ll never meet.\" }";
+        String category = null; // No category specified
+        int numJokes = 1; // Assuming you want 1 joke
+        when(mockJokeQueryService.getJSON(eq(category), eq(numJokes))).thenReturn(fakeJsonResult);
+
+        String url = String.format("/api/jokes/get?numJokes=%d", numJokes);
+
+        MvcResult response = mockMvc
+            .perform(get(url).contentType("application/json"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(fakeJsonResult, responseString);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/JokeControllerTests.java
@@ -31,7 +31,7 @@ public class JokeControllerTests {
     public void test_getRandomJoke() throws Exception {
     
         String fakeJsonResult = "{ \"joke\" : \"Why don't scientists trust atoms? Because they make up everything!\" }";
-        String category = "dad";
+        String category = "program";
         int numJokes = 1; // Assuming you want 1 joke
         when(mockJokeQueryService.getJSON(eq(category), eq(numJokes))).thenReturn(fakeJsonResult);
 

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/JokeQueryServiceTests.java
@@ -1,0 +1,41 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(JokeQueryService.class)
+public class JokeQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private JokeQueryService jokeQueryService;
+
+    @Test
+    public void test_getJSON() {
+        String category = "Any";
+        int numJokes = 5;
+        String expectedURL = JokeQueryService.ENDPOINT.replace("{category}", category)
+                                                     .replace("{numJokes}", Integer.toString(numJokes));
+
+        String fakeJsonResult = "{ \"fake\" : \"joke\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                                  .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                                  .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                                  .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = jokeQueryService.getJSON(category, numJokes);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+}


### PR DESCRIPTION
In this PR, we add an endpoint `joke/get` that can be used to get information
about the location of a particular zipcode.

 dev: http://team01-shakcmpsc-dev.dokku-07.cs.ucsb.edu

Closes #7 